### PR TITLE
Support Railway Postgres configuration

### DIFF
--- a/db.py
+++ b/db.py
@@ -12,12 +12,34 @@ load_dotenv()
 
 @lru_cache(maxsize=1)
 def get_database_url() -> str:
-	url = os.getenv("DATABASE_URL")
-	if not url:
-		# Allow missing URL in test contexts; some endpoints/tests may not need DB.
-		# We avoid raising here; downstream callers should handle absent URL.
-		return ""
-	return url
+        """Return a PostgreSQL connection URL from the environment.
+
+        Railway exposes both ``DATABASE_URL`` (internal) and
+        ``DATABASE_PUBLIC_URL`` (external).  For local usage we also allow
+        constructing the URL from ``POSTGRES_*`` variables.  Tests that do not
+        require a database can run without any of these variables defined.
+        """
+
+        url = os.getenv("DATABASE_URL") or os.getenv("DATABASE_PUBLIC_URL")
+
+        if not url:
+                host = os.getenv("POSTGRES_HOST")
+                db = os.getenv("POSTGRES_DB")
+                user = os.getenv("POSTGRES_USER", "postgres")
+                password = os.getenv("POSTGRES_PASSWORD")
+                port = os.getenv("POSTGRES_PORT", "5432")
+                if host and db:
+                        if password:
+                                url = f"postgresql://{user}:{password}@{host}:{port}/{db}"
+                        else:
+                                url = f"postgresql://{user}@{host}:{port}/{db}"
+
+        if not url:
+                # Allow missing URL in test contexts; some endpoints/tests may not need DB.
+                # We avoid raising here; downstream callers should handle absent URL.
+                return ""
+
+        return url
 
 
 @lru_cache(maxsize=1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ scipy==1.13.1
 pydantic==2.8.2
 cachetools==5.3.3
 pytest==8.3.2
+httpx==0.27.2
 


### PR DESCRIPTION
## Summary
- expand database URL resolver to use Railway-provided variables
- include `httpx` dependency for running tests

## Testing
- `pytest` *(fails: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68b0678e32e48330a3e270591e042d2d