### PR TITLE
Add root endpoint to return API message

### DIFF
--- a/app.py
+++ b/app.py
@@ -302,9 +302,14 @@ SELECT
 """
 
 
+@app.get("/", include_in_schema=False)
+def root():
+        """Simple root endpoint to avoid 404 at the base URL."""
+        return {"message": "Curvas de Desembolso API"}
+
 @app.get("/api/health")
 def health():
-	return {"status": "ok"}
+        return {"status": "ok"}
 
 
 @app.options("/api/filters")


### PR DESCRIPTION
## Summary
- add a root endpoint so hitting the base URL no longer returns 404

## Testing
- `pip install httpx` *(fails: Cannot connect to proxy)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68b0698d95388330a2122f95e96c3d7b