### PR TITLE
Expose combined prediction band points

### DIFF
--- a/app.py
+++ b/app.py
@@ -1108,6 +1108,18 @@ def prediction_bands(
     p2_5 = q[0.025].tolist()
     p97_5 = q[0.975].tolist()
 
+    bands = [
+        {
+            "k": k,
+            "p50": m,
+            "p10": lo,
+            "p90": hi,
+            "p2_5": lo2,
+            "p97_5": hi2,
+        }
+        for k, m, lo, hi, lo2, hi2 in zip(k_vals, p50, p10, p90, p2_5, p97_5)
+    ]
+
     # Percentile of latest project point within cohort distribution
     current_percentile = None
     if proj_k:
@@ -1158,6 +1170,7 @@ def prediction_bands(
         "p90": p90,
         "p2_5": p2_5,
         "p97_5": p97_5,
+        "bands": bands,
         "project_k": proj_k,
         "project_y": proj_y,
         "current_percentile": current_percentile,

--- a/models.py
+++ b/models.py
@@ -123,24 +123,36 @@ class PredictionMeta(BaseModel):
 
 
 class EtaMetrics(BaseModel):
-        median: Optional[float] = None
-        p10: Optional[float] = None
-        p90: Optional[float] = None
+    median: Optional[float] = None
+    p10: Optional[float] = None
+    p90: Optional[float] = None
+
+
+class PredictionBandPoint(BaseModel):
+    """Single prediction band point across quantiles."""
+
+    k: int
+    p50: float
+    p10: float
+    p90: float
+    p2_5: float
+    p97_5: float
 
 
 class PredictionBandsResponse(BaseModel):
-        project_id: str
-        k: List[int]
-        p50: List[float]
-        p10: List[float]
-        p90: List[float]
-        p2_5: List[float]
-        p97_5: List[float]
-        project_k: List[int]
-        project_y: List[float]
-        current_percentile: Optional[float] = None
-        eta: EtaMetrics = Field(default_factory=EtaMetrics)
-        alerts: List[str] = Field(default_factory=list)
-        meta: PredictionMeta
+    project_id: str
+    k: List[int]
+    p50: List[float]
+    p10: List[float]
+    p90: List[float]
+    p2_5: List[float]
+    p97_5: List[float]
+    project_k: List[int]
+    project_y: List[float]
+    current_percentile: Optional[float] = None
+    eta: EtaMetrics = Field(default_factory=EtaMetrics)
+    alerts: List[str] = Field(default_factory=list)
+    meta: PredictionMeta
+    bands: List[PredictionBandPoint] | None = None
 
 

--- a/test_prediction_bands.py
+++ b/test_prediction_bands.py
@@ -75,6 +75,16 @@ def test_prediction_bands_quantiles(monkeypatch):
     assert j["meta"]["method"] == "historical_quantiles"
     assert len(j["k"]) == len(j["p50"]) == len(j["p10"]) == len(j["p90"]) == len(j["p2_5"]) == len(j["p97_5"])
     assert len(j["project_k"]) == len(j["project_y"])
+    assert len(j["bands"]) == len(j["k"])
+    for bp, k, p50, p10, p90, p2_5, p97_5 in zip(
+        j["bands"], j["k"], j["p50"], j["p10"], j["p90"], j["p2_5"], j["p97_5"],
+    ):
+        assert bp["k"] == k
+        assert bp["p50"] == p50
+        assert bp["p10"] == p10
+        assert bp["p90"] == p90
+        assert bp["p2_5"] == p2_5
+        assert bp["p97_5"] == p97_5
     assert "current_percentile" in j and 0.0 <= j["current_percentile"] <= 1.0
     assert j["eta"]["median"] is not None
     assert isinstance(j["alerts"], list)


### PR DESCRIPTION
## Summary
- bundle prediction band quantiles into `bands` list for easier graphing
- add `PredictionBandPoint` model and update response schema
- extend tests to verify bundled band points

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4f0f1b7e48330989da167519d0d2f