### PR TITLE
Clean up unused imports and fix indentation

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,18 +2,15 @@ import json
 import math
 import os
 import random
-from datetime import date
-from typing import Dict, List, Tuple, Set
+from typing import List, Tuple, Set
 
 import numpy as np
 import pandas as pd
 from cachetools import TTLCache
 from fastapi import Depends, FastAPI, HTTPException, Query, Response
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import ValidationError
 from sqlalchemy import text
 from sqlalchemy.engine import Row
-from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.orm import Session
 
 from db import get_db, get_engine
@@ -845,9 +842,12 @@ def fit_curve(payload: FiltersRequest, db: Session = Depends(get_db)):
 			k30_b = solve_k_local(0.3)
 			k50_b = solve_k_local(0.5)
 			k80_b = solve_k_local(0.8)
-			if k30_b is not None: k30_samples.append(k30_b)
-			if k50_b is not None: k50_samples.append(k50_b)
-			if k80_b is not None: k80_samples.append(k80_b)
+			if k30_b is not None:
+				k30_samples.append(k30_b)
+			if k50_b is not None:
+				k50_samples.append(k50_b)
+			if k80_b is not None:
+				k80_samples.append(k80_b)
 		# Percentiles
 		def pct(arr: list[float], p_low: float = 2.5, p_hi: float = 97.5):
 			if not arr:

--- a/db.py
+++ b/db.py
@@ -1,6 +1,5 @@
 import os
 from functools import lru_cache
-from typing import Optional
 
 from dotenv import load_dotenv
 from sqlalchemy import create_engine

--- a/test_app.py
+++ b/test_app.py
@@ -1,4 +1,3 @@
-import types
 import os
 import random
 import sys
@@ -19,7 +18,6 @@ def test_health():
 
 def test_curve_fit_monkeypatch(monkeypatch):
     # Monkeypatch the base query to avoid DB
-    from app import _run_base_query
 
     def fake_run_base_query(filters, db, status_target='ALL', *, select_meta=True):
         # Generate synthetic logistic-ish data for multiple projects


### PR DESCRIPTION
## Summary
- remove unused imports from application and database modules
- expand inline `if` statements for sample collection into properly-indented blocks
- drop stray imports in tests

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4f6fbe4bc8330ab195b9404ad6b67