### PR TITLE
feat: refine prediction bands with quantile handling

### DIFF
--- a/models.py
+++ b/models.py
@@ -120,6 +120,7 @@ class PredictionMeta(BaseModel):
         smooth: bool
         num_points: int
         notes: str = ""
+        low_sample: bool | None = None
 
 
 class EtaMetrics(BaseModel):


### PR DESCRIPTION
## Summary
- support excluding a project from prediction-band cohorts
- enforce empirical quantile bands to be monotonic and within [0,1]
- flag low sample sizes in prediction metadata

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4fe5eb5c48330bf023aed05f2a061