### PR TITLE
Improve prediction band sampling and coverage metadata

### DIFF
--- a/models.py
+++ b/models.py
@@ -114,13 +114,18 @@ class ProjectTimeseriesResponse(BaseModel):
         series: List[ProjectTimeseriesPoint]
 
 
+class Coverage(BaseModel):
+        outer: Optional[float] = None
+        inner: Optional[float] = None
+
+
 class PredictionMeta(BaseModel):
         method: str
-        level: float
+        coverage: Coverage
         smooth: bool
         num_points: int
         notes: str = ""
-        low_sample: bool | None = None
+        coverage_empirical: Coverage | None = None
 
 
 class EtaMetrics(BaseModel):
@@ -138,6 +143,8 @@ class PredictionBandPoint(BaseModel):
     p90: float
     p2_5: float
     p97_5: float
+    n: int
+    low_sample: bool
 
 
 class PredictionBandsResponse(BaseModel):
@@ -149,7 +156,9 @@ class PredictionBandsResponse(BaseModel):
     p90: List[float]
     p2_5: List[float]
     p97_5: List[float]
+    n: List[int]
     meta: PredictionMeta
     bands: List[PredictionBandPoint] | None = None
+    project: ProjectTimeseriesResponse | None = None
 
 


### PR DESCRIPTION
## Summary
- Report per-k sample counts with low-sample flag and optional project overlay
- Replace confidence level with coverage metadata and expose empirical coverage in debug mode
- Extend models and tests for new fields and behaviour

## Testing
- `python3 -m py_compile app.py models.py test_prediction_bands.py`
- `python3 -m pytest -q` *(fails: No module named pytest)*


------
https://chatgpt.com/codex/tasks/task_e_68b598c9d7188330a46107a5d601bab7